### PR TITLE
Multiple (mostly crypto) Improvements

### DIFF
--- a/src/authentication-password-management/communicating-authentication-data.md
+++ b/src/authentication-password-management/communicating-authentication-data.md
@@ -64,12 +64,12 @@ With a generic message you do not disclose:
 * How your system works: "Invalid password" reveals how your application works
 
 ```go
-  record, err = db.Query("SELECT password FROM accounts WHERE username = ?", username)
+  record, err = db.Query("SELECT passwordHash FROM accounts WHERE username = ?", username)
   if err != nil {
     // user does not exist
   }
 
-  if subtle.ConstantTimeCompare([]byte(record[0]), []byte(password)) != 1 {
+  if subtle.ConstantTimeCompare([]byte(record[0]), []byte(attemptPasswordHash)) != 1 {
     // passwords do not match
   }
 ```

--- a/src/authentication-password-management/validation-and-storage.md
+++ b/src/authentication-password-management/validation-and-storage.md
@@ -36,7 +36,8 @@ different from `H(p2)`[^1].
 Does this sound, or look, like Math?
 Pay attention to this last requirement: `H` should be such a function that
 there's no function `H⁻¹` so that `H⁻¹(H(p1))` is equal to `p1`. This means
-that there's no way back to the original `p1`.
+that there's no way back to the original `p1`, unless you try all possible
+values of `p`.
 
 If `H` is one-way only, what's the real problem about account leakage?
 
@@ -51,18 +52,17 @@ How can we avoid this?
 
 The point is: if two different users provide the same password `p1` we should
 store a different hashed value.
-It may sound impossible but the answer is `salt`: a pseudo-random value which is
+It may sound impossible but the answer is `salt`: a pseudo-random **unique** value which is
 append to `p1` so that the resulting hash is computed as follow: `H(p1 + salt)`.
 
 So each entry on passwords store should keep the resulting hash and the `salt`
 itself in plaintext: `salt` does not offer any security concerns.
 
 Last recommendations.
-* Avoid using MD5 hashing algorithm whenever possible;
-* Avoid using SHA1 as it has been cracked recently.
+* Avoid using deprecated hashing algorithms (e.g. SHA-1, MD5, etc)
 * Read the [Pseudo-Random Generators section][1].
 
-The following example shows a basic example of how this works:
+The following code-sample shows a basic example of how this works:
 
 ```go
 package main
@@ -118,10 +118,10 @@ here only to illustrate the theory with a practical example. The next section
 explains how to correctly salt passwords in real life.
 
 
-Storing password securely: the practice
+Storing password securely: in practice
 ---------------------------------------
 
-One of the most important adage in cryptography is: **never write your own
+One of the most important adage in cryptography is: **never roll your own
 crypto**. By not doing so, one can put at risk the entire application. It is a
 sensitive and complex topic. Hopefully, cryptography provides tools and
 standards reviewed and approved by experts. It is therefore important to use
@@ -130,7 +130,7 @@ them instead of trying to re-invent the wheel.
 In the case of password storage, the hashing algorithms recommended by
 [OWASP][2] are [`bcrypt`][2], [`PDKDF2`][3], [`Argon2`][4] and [`scrypt`][5].
 Those take care of hashing and salting passwords in a robust way. Go authors
-provides an extended package for cryptography, that is not part of the standard
+provide an extended package for cryptography, that is not part of the standard
 library. It provides robust implementations for most of the aforementioned
 algorithms. It can be downloaded using  `go get`:
 

--- a/src/authentication-password-management/validation-and-storage.md
+++ b/src/authentication-password-management/validation-and-storage.md
@@ -52,11 +52,12 @@ How can we avoid this?
 
 The point is: if two different users provide the same password `p1` we should
 store a different hashed value.
-It may sound impossible but the answer is `salt`: a pseudo-random **unique** value which is
-append to `p1` so that the resulting hash is computed as follow: `H(p1 + salt)`.
+It may sound impossible but the answer is `salt`: a pseudo-random **unique per user password** 
+value which is appended to `p1` so that the resulting hash is computed as follows:
+`H(p1 + salt)`.
 
 So each entry on passwords store should keep the resulting hash and the `salt`
-itself in plaintext: `salt` does not offer any security concerns.
+itself in plaintext: `salt` is not required to remain private.
 
 Last recommendations.
 * Avoid using deprecated hashing algorithms (e.g. SHA-1, MD5, etc)
@@ -118,11 +119,11 @@ here only to illustrate the theory with a practical example. The next section
 explains how to correctly salt passwords in real life.
 
 
-Storing password securely: in practice
+Storing password securely: the practice
 ---------------------------------------
 
 One of the most important adage in cryptography is: **never roll your own
-crypto**. By not doing so, one can put at risk the entire application. It is a
+crypto**. By doing so, one can put at risk the entire application. It is a
 sensitive and complex topic. Hopefully, cryptography provides tools and
 standards reviewed and approved by experts. It is therefore important to use
 them instead of trying to re-invent the wheel.

--- a/src/cryptographic-practices/README.md
+++ b/src/cryptographic-practices/README.md
@@ -15,10 +15,11 @@ hash := F(data)
 The hash has fixed length and its value vary widely with small variations in
 input (collisions may still happen). A good hashing algorithm won't allow to
 turn a hash into its original source[^1]. MD5 is the most popular hashing
-algorithm but securitywise SHA-256 is considered the strongest.
+algorithm but securitywise BLAKE2 is considered the strongest and most flexible.
+However, BLAKE2 has no official implementation in Go yet, so we fallback to SHA-256.
 Whenever you have something that you don't need to know what it is but only if
-it is what it is supposed to be (like users' passwords), you should use
-hashing[^2]
+it is what it is supposed to be (like checking file integrity after download), 
+you should use hashing[^2]
 
 ```go
 package main
@@ -62,9 +63,20 @@ Encryption should be used whenever you need to communicate or store sensitive
 data, which you or someone else needs to access later on for further
 processing. A "simple" encryption use case is the HTTPS - Hyper Text Transfer
 Protocol Secure.
-AES is the _de facto_ standard when it comes to symmetric key encryption. On
-the other hand, you have Public key cryptography or asymmetric cryptography
-which makes use of pairs of keys: public and private
+AES is the _de facto_ standard when it comes to symmetric key encryption. This
+algorithm, as many other symmetric ciphers, can be implemented in different modes.
+You'll notice in the code sample below, GCM (Galois Counter Mode) was used, instead
+of the more popular (in cryptography code examples, at least) CBC/ECB.
+The main difference between GCM and CBC/ECB is the fact that the former is an
+**authenticated** cipher mode, meaning that after the encryption stage, an
+authentication tag is added to the ciphertext, which will then be validated **prior**
+to message decryption, ensuring the message has not been tampered with.
+On the other hand, you have Public key cryptography or asymmetric cryptography
+which makes use of pairs of keys: public and private. Public key cryptography
+is less performant as symmetric key cryptography for most cases, so its most 
+common use-case is sharing a symmetric key between two parties using
+assymetric cryptography, so they can then use the symmetric key to exchange 
+messages encrypted with symmetric cryptography.
 
 ```go
 package main
@@ -118,6 +130,9 @@ hardcoded in the source code (as it is on this example).
 
 [Go's crypto package][1] collects common cryptographic constants, but
 implementations have their own packages, as the [crypto/md5][2] one.
+
+Most modern cryptographic algorthims have been implemented under https://godoc.org/golang.org/x/crypto, so
+developers should focus on those instead of the implementations in the [crypto/*] package..
 
 ---
 

--- a/src/cryptographic-practices/README.md
+++ b/src/cryptographic-practices/README.md
@@ -77,6 +77,19 @@ is less performant as symmetric key cryptography for most cases, so its most
 common use-case is sharing a symmetric key between two parties using
 assymetric cryptography, so they can then use the symmetric key to exchange 
 messages encrypted with symmetric cryptography.
+Aside from AES, which is 90's technology, Go authors have begun to implement and
+support more modern symmetric encryption algorthims which also provide authentication,
+such as chacha20poly1305.
+
+Another interesting package in Go is x/crypto/nacl. This is a reference to
+Dr. Daniel J. Bernstein's NaCl library, which is a very popular modern cryptography library.
+The nacl/box and nacl/secretbox in Go are implementations of NaCl's abstractions for sending
+encrypted messages for the two most common use-cases:
+- Sending authenticated, encrypted messages between two parties using public key cryptography (nacl/box)
+- Sending authenticated, encrytped messages between two parties using symmetric (a.k.a secret-key) cryptography
+
+It is very advisable to use one of these abstractions instead of direct use of AES, if they fit your
+situation.
 
 ```go
 package main

--- a/src/cryptographic-practices/README.md
+++ b/src/cryptographic-practices/README.md
@@ -78,7 +78,7 @@ common use-case is sharing a symmetric key between two parties using
 assymetric cryptography, so they can then use the symmetric key to exchange 
 messages encrypted with symmetric cryptography.
 Aside from AES, which is 90's technology, Go authors have begun to implement and
-support more modern symmetric encryption algorthims which also provide authentication,
+support more modern symmetric encryption algorithms which also provide authentication,
 such as chacha20poly1305.
 
 Another interesting package in Go is x/crypto/nacl. This is a reference to
@@ -86,10 +86,10 @@ Dr. Daniel J. Bernstein's NaCl library, which is a very popular modern cryptogra
 The nacl/box and nacl/secretbox in Go are implementations of NaCl's abstractions for sending
 encrypted messages for the two most common use-cases:
 - Sending authenticated, encrypted messages between two parties using public key cryptography (nacl/box)
-- Sending authenticated, encrytped messages between two parties using symmetric (a.k.a secret-key) cryptography
+- Sending authenticated, encrypted messages between two parties using symmetric (a.k.a secret-key) cryptography
 
 It is very advisable to use one of these abstractions instead of direct use of AES, if they fit your
-situation.
+use-case.
 
 ```go
 package main

--- a/src/cryptographic-practices/pseudo-random-generators.md
+++ b/src/cryptographic-practices/pseudo-random-generators.md
@@ -42,7 +42,7 @@ Random Number:  1825
 ```
 
 Because [Go's math/rand][1] is a deterministic pseudo-random number generator like
-many others they use a source, called a Seed. This Seed is responsible for changing
+many others they use a source, called a Seed. This Seed is **solely** responsible for
 the randomness of the deterministic pseudo-random number generator -- if it is known
 or predictable, the same will happen to generated number sequence.
 

--- a/src/cryptographic-practices/pseudo-random-generators.md
+++ b/src/cryptographic-practices/pseudo-random-generators.md
@@ -69,9 +69,9 @@ func main() {
 ```
 
 You may notice that running [crypto/rand][4] is slower than [math/rand][1] but
-this is expected: the fastest algorithm isn't always the safest. Another example
-of this, is the fact that you *CANNOT* seed crypto/rand, the library uses OS-randomness
-for this, preventing developer misuse.
+this is expected: the fastest algorithm isn't always the safest. Crypto's rand is
+also safer to implement; an example of this, is the fact that you *CANNOT* seed 
+crypto/rand, the library uses OS-randomness for this, preventing developer misuse.
 
 ```bash
 $ for i in {1..5}; do go run rand-safe.go; done

--- a/src/cryptographic-practices/pseudo-random-generators.md
+++ b/src/cryptographic-practices/pseudo-random-generators.md
@@ -8,7 +8,7 @@ number generator when these random values are intended to be un-guessable_", so
 let's talk about "random numbers".
 
 Cryptography relies on some randomness, but for the sake of correctness what
-most programming languages provide out-of-the-box is a **pseudo**-random number
+most programming languages provide out-of-the-box is a pseudo-random number
 generator: [Go's math/rand][1] is not an exception.
 
 You should carefully read the documentation when it states that "_Top-level
@@ -41,8 +41,11 @@ Random Number:  1825
 Random Number:  1825
 ```
 
-Because [Go's math/rand][1] is just a **pseudo**-random number generator like
-many others and they use a source.
+Because [Go's math/rand][1] is a deterministic pseudo-random number generator like
+many others they use a source, called a Seed. This Seed is responsible for changing
+the randomness of the deterministic pseudo-random number generator -- if it is known
+or predictable, the same will happen to generated number sequence.
+
 We could "fix" this example quite easily by using the [math/rand Seed function][3]
 getting the expected five different values for each program execution, but
 because we're on Cryptographic Practices section we should follow to
@@ -66,7 +69,9 @@ func main() {
 ```
 
 You may notice that running [crypto/rand][4] is slower than [math/rand][1] but
-this is expected: not always is the fastest algorithm the safest.
+this is expected: the fastest algorithm isn't always the safest. Another example
+of this, is the fact that you *CANNOT* seed crypto/rand, the library uses OS-randomness
+for this, preventing developer misuse.
 
 ```bash
 $ for i in {1..5}; do go run rand-safe.go; done


### PR DESCRIPTION
Hi guys,

Great job on the SCP 👍
I did find a couple of issues on the crypto side of it, so here's a PR with my suggested changes.

Best regards,
João

CHANGELOG:
Authentication and password management - Validation and Storage:
- Fixed typos and changed conceptual phrasing for clarity
- Added uniqueness requirement for salts
- Fixed the crypto adage :)

Cryptographic Practices:
- Fixed typos and changed conceptual phrasing for clarity
- Terminology matters: I suggest (but did not implement) a global change in the document from hash to KDF (Key Derivation Function) whenever referring to a function that takes as input a user-supplied password to derive a hash or encryption key ( Argon2,scrypt,bcrypt,etc. ); and using hash when talking about the hash primitive functions ( SHA, BLAKE, etc. ) or their output only. This prevents a lot of confusion for first-time readers.
- Changed SHA-256 to BLAKE2 as it is the most modern, secure, flexible and fast hashing algorithm at the moment
- Added small explanation about cipher modes
- Added small explanation about public key cryptography
- Added reference to NaCl/box and NaCl/secretbox (libsodium)
- SHA-1 is not **broken** per se, that would mean a break of its second pre-image resistance, which is not the same as the collision breakthrough by the Google team earlier this year -- that being said, it's still time to stop using it, so let's just call it "deprecated".

PRNGs:
- Fixed typos and changed conceptual phrasing for clarity
- Added explanation of what the Seed is
- Fixed terminology: all software random number generators are pseudo-random number generators -- for true randomness one need would need a hardware source.