### PR TITLE
Use rand.Read in place of io.ReadFull(rand.Reader, ...)

### DIFF
--- a/src/authentication-password-management/validation-and-storage.md
+++ b/src/authentication-password-management/validation-and-storage.md
@@ -74,7 +74,6 @@ import (
     "database/sql"
     "context"
     "fmt"
-    "io"
 )
 
 const saltSize = 32
@@ -86,7 +85,7 @@ func main() {
 
     // create random word
     salt := make([]byte, saltSize)
-    _, err := io.ReadFull(rand.Reader, salt)
+    _, err := rand.Read(salt)
     if err != nil {
         panic(err)
     }

--- a/src/cryptographic-practices/README.md
+++ b/src/cryptographic-practices/README.md
@@ -103,7 +103,6 @@ AES, if they fit your use-case.
 package main
 
 import "fmt"
-import "io"
 import "crypto/aes"
 import "crypto/cipher"
 import "crypto/rand"
@@ -118,7 +117,7 @@ func main() {
         }
 
         nonce := make([]byte, 12)
-        if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+        if _, err := rand.Read(nonce); err != nil {
                 panic(err.Error())
         }
 

--- a/src/data-protection/README.md
+++ b/src/data-protection/README.md
@@ -127,7 +127,7 @@ copy(secretKey[:], secretKeyBytes)
 // same key. Since the nonce here is 192 bits long, a random value
 // provides a sufficiently small probability of repeats.
 var nonce [24]byte
-if _, err := io.ReadFull(rand.Reader, nonce[:]); err != nil {
+if _, err := rand.Read(nonce[:]); err != nil {
     panic(err)
 }
 


### PR DESCRIPTION
`rand.Read` uses `io.ReadFull` internally, so the new code is equivalent to the
old. Just more concise and uses fewer imports.