### PR TITLE
Correct code to use QueryRowContext

### DIFF
--- a/src/authentication-password-management/communicating-authentication-data.md
+++ b/src/authentication-password-management/communicating-authentication-data.md
@@ -68,7 +68,7 @@ With a generic message you do not disclose:
   var value string
 
   ctx := context.Background()
-  err := db.QueryContext(ctx, "SELECT passwordHash FROM accounts WHERE username = ?", username).Scan(&value)
+  err := db.QueryRowContext(ctx, "SELECT passwordHash FROM accounts WHERE username = ?", username).Scan(&value)
 
   // we don't really care about `err` as a measure to prevent timing attacks:
   // as we always do a Constant Time Compare


### PR DESCRIPTION
The old code didn't actually compile. It was using `QueryContext`, which returns
`(*sql.Rows, err)`, but this code only expected one value.

The new code is probably what was originally intended.